### PR TITLE
Add Varbinary column class

### DIFF
--- a/src/Processor/CreateProcessor.php
+++ b/src/Processor/CreateProcessor.php
@@ -165,7 +165,7 @@ final class CreateProcessor
                 return $timestamp;
 
             case DataType::VARBINARY:
-                throw new \UnexpectedValueException('VARBINARY is not yet supported');
+                return new Column\Varbinary((int) $stmt->length);
 
             case DataType::JSON:
                 throw new \UnexpectedValueException('JSON is not yet supported');

--- a/src/Schema/Column/Varbinary.php
+++ b/src/Schema/Column/Varbinary.php
@@ -1,0 +1,12 @@
+<?php
+namespace Vimeo\MysqlEngine\Schema\Column;
+
+class Varbinary extends CharacterColumn implements BlobColumn, Defaultable
+{
+    use MySqlDefaultTrait;
+
+    public function __construct(int $max_string_length)
+    {
+        parent::__construct($max_string_length, 'binary', '_bin');
+    }
+}


### PR DESCRIPTION
[varbinary](https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html) is similar to [`Varchar`](https://github.com/vimeo/php-mysql-engine/blob/master/src/Schema/Column/Varchar.php) and [`Blob`](https://github.com/vimeo/php-mysql-engine/blob/master/src/Schema/Column/Blob.php).