### PR TITLE
Add license declaration to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "vimeo/php-mysql-engine",
   "description": "A MySQL engine written in PHP for speeding up tests",
   "type": "library",
+  "license": "MIT",
   "authors": [
     {
       "name": "Scott Sandler",


### PR DESCRIPTION
The project does not have a license declaration in it's `composer.json` which can lead to issues with automatic checking tools like `metasyntactical/composer-plugin-license-check`

The license file in the repository seems to be `MIT` so I've added that.

## Example license checker issue

![image](https://user-images.githubusercontent.com/1770056/106543807-71cc7080-64d4-11eb-8c59-f9be0be50afc.png)
