### PR TITLE
feat(TruncateParser): update `TRUNCATE`

### DIFF
--- a/src/Parser/SQLParser.php
+++ b/src/Parser/SQLParser.php
@@ -35,6 +35,7 @@ final class SQLParser
         'VALUES' => true,
         'DROP' => true,
         'SHOW' => true,
+        'TRUNCATE' => true,
     ];
 
     /**
@@ -168,7 +169,7 @@ final class SQLParser
             $tokens = \array_slice($tokens, 1, $close - 1);
             $token = $tokens[0];
         }
-        if ($token->type !== TokenType::CLAUSE && $token->value !== 'TRUNCATE') {
+        if ($token->type !== TokenType::CLAUSE) {
             throw new ParserException("Unexpected {$token->value}");
         }
         switch ($token->value) {

--- a/src/Parser/TruncateParser.php
+++ b/src/Parser/TruncateParser.php
@@ -23,6 +23,7 @@ final class TruncateParser
 
     /**
      * @param array<int, Token> $tokens
+     * @param string            $sql
      */
     public function __construct(array $tokens, string $sql)
     {
@@ -30,18 +31,31 @@ final class TruncateParser
         $this->sql = $sql;
     }
 
+    /**
+     * @return TruncateQuery
+     * @throws ParserException
+     */
     public function parse() : TruncateQuery
     {
-        if ($this->tokens[$this->pointer]->value !== 'TRUNCATE') {
-            throw new ParserException("Parser error: expected TRUNCATE");
+        $token = $this->tokens[$this->pointer] ?? null;
+        if ($token === null) {
+            throw new ParserException('Parser error: invalid tokens');
+        }
+        if ($token->value !== 'TRUNCATE') {
+            throw new ParserException('Parser error: expected TRUNCATE');
         }
 
         $this->pointer++;
 
-        $token = $this->tokens[$this->pointer];
+        $token = $this->tokens[$this->pointer] ?? null;
+
+        if ($token!==null && $token->value === 'TABLE' && $token->type===TokenType::RESERVED) {
+            $this->pointer++;
+            $token = $this->tokens[$this->pointer] ?? null;
+        }
 
         if ($token === null || $token->type !== TokenType::IDENTIFIER) {
-            throw new ParserException("Expected table name after TRUNCATE");
+            throw new ParserException('Expected table name after TRUNCATE');
         }
 
         return new TruncateQuery($token->value, $this->sql);

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -870,6 +870,37 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         $query->fetchColumn($columnIndex);
     }
 
+    public function dataProviderTruncateForms(): array
+    {
+        return [
+            'short'       => ['TRUNCATE'],
+            'long'        => ['TRUNCATE TABLE'],
+            'lower short' => ['TRUNCATE'],
+            'lower long'  => ['TRUNCATE TABLE'],
+        ];
+    }
+
+    /**
+     * @param string $truncateForm
+     *
+     * @dataProvider dataProviderTruncateForms
+     */
+    public function testTruncate(string $truncateForm)
+    {
+        $pdo = self::getConnectionToFullDB(false);
+
+        // check that table some data
+        $this->assertGreaterThan(
+            0,
+            $pdo->query('SELECT count(*) FROM `video_game_characters`')->fetchColumn(0)
+        );
+        $pdo->exec($truncateForm . ' video_game_characters');
+        $this->assertEquals(
+            0,
+            $pdo->query('SELECT count(*) FROM `video_game_characters`')->fetchColumn(0)
+        );
+    }
+
     private static function getPdo(string $connection_string, bool $strict_mode = false) : \PDO
     {
         $options = $strict_mode ? [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode="STRICT_ALL_TABLES"'] : [];

--- a/tests/TruncateParseTest.php
+++ b/tests/TruncateParseTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Vimeo\MysqlEngine\Tests;
+
+use Vimeo\MysqlEngine\Parser\ParserException;
+use Vimeo\MysqlEngine\Parser\SQLParser;
+use Vimeo\MysqlEngine\Parser\Token;
+use Vimeo\MysqlEngine\Parser\TruncateParser;
+use Vimeo\MysqlEngine\Query\TruncateQuery;
+use Vimeo\MysqlEngine\TokenType;
+
+use function array_shift;
+use function sprintf;
+
+class TruncateParseTest extends \PHPUnit\Framework\TestCase
+{
+
+    public function dataProviderInvalidTokens(): array
+    {
+        return [
+            'empty array'                         => [
+                [],
+            ],
+            'associative array (equals to empty)' => [
+                [
+                    'a' => new Token(TokenType::CLAUSE, 'SELECT', 'SELECT', 0),
+                    'b' => new Token(TokenType::IDENTIFIER, 'table_name', 'table_name', 0),
+                ],
+            ],
+            'select'                              => [
+                [
+                    new Token(TokenType::CLAUSE, 'SELECT', 'SELECT', 0),
+                ],
+            ],
+            'invalid token type'                  => [
+                [
+                    new Token(TokenType::CLAUSE, 'TRUNCATE', 'TRUNCATE', 0),
+                    new Token(TokenType::RESERVED, 'TRUNCATE', 'TRUNCATE', 0),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, Token> $tokens
+     *
+     * @dataProvider dataProviderInvalidTokens
+     */
+    public function testInvalidTokens(array $tokens): void
+    {
+        $parser = new TruncateParser($tokens, '');
+        $this->expectException(ParserException::class);
+        $parser->parse();
+    }
+
+    /**
+     * @return array<string, {0: string}>
+     */
+    public function dataProviderQueryForms(): array
+    {
+        return [
+            'short'       => ['TRUNCATE %s'],
+            'long'        => ['TRUNCATE TABLE %s'],
+            'lower short' => ['truncate %s'],
+            'lower long'  => ['truncate table %s'],
+        ];
+    }
+
+    /**
+     * @param string $form
+     *
+     * @dataProvider dataProviderQueryForms
+     */
+    public function testTruncate(string $form): void
+    {
+        $query = sprintf($form, '`table_name`');
+
+        $truncate_query = SQLParser::parse($query);
+
+        self::assertInstanceOf(TruncateQuery::class, $truncate_query);
+    }
+
+    /**
+     * @param string $form
+     *
+     * @dataProvider dataProviderQueryForms
+     */
+    public function testTruncateTable(string $form): void
+    {
+        $query = sprintf($form, '`table_name`');
+
+        $truncate_query = SQLParser::parse($query);
+
+        self::assertInstanceOf(TruncateQuery::class, $truncate_query);
+    }
+
+    /**
+     * @param string $query
+     *
+     * @dataProvider dataProviderInvalidStatements
+     */
+    public function testInvalidStatement(string $query): void
+    {
+        $this->expectException(ParserException::class);
+
+        SQLParser::parse($query);
+    }
+
+    public function dataProviderInvalidStatements(): \Generator
+    {
+        foreach ([
+                 // this check uses anything that is NOT a identifier
+                 //   will result to `truncate table select`
+                'invalid identifier' => 'select',
+
+                 // missing identifier checks
+                 //   will result to `truncate table`
+                'missing identifier' => '',
+            ] as $case => $identifier
+        ) {
+            foreach ($this->dataProviderQueryForms() as $formName => $sql) {
+                yield $case . ': ' . $formName => [sprintf(array_shift($sql), $identifier)];
+            }
+        }
+    }
+}


### PR DESCRIPTION
 - promote truncate to clause, that also allows to use lowercase form `truncate`
 - add optional form `TRUNCATE TABLE <table name>`
 - add check for invalid `$tokens` array at `TruncateParser::parse` (ex. empty array), this could be helpful for direct usage of `TruncateParser` class (I don't know who will ever need this, but this is the way things should be done)
 - add unit tests for `TruncateParser` class