### PR TITLE
fix(DataIntegrity): fix psalm error about concatenation of `string` and `mixed`

### DIFF
--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -163,7 +163,9 @@ final class DataIntegrity
             }
 
             if (!\is_numeric($value)) {
-                throw new Processor\InvalidValueException('Number column expects a numeric value, but saw ' . $value);
+                throw new Processor\InvalidValueException(
+                    'Number column expects a numeric value, but saw ' . var_export($value, true)
+                );
             }
 
             if ((float) $value > $column->getMaxValue()) {


### PR DESCRIPTION
using `var_export` is a bit overkill but should do the job