### PR TITLE
fix(Truncate/Drop): fix parsing of table-name

### DIFF
--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -213,18 +213,14 @@ trait FakePdoStatementTrait
                 break;
 
             case Query\TruncateQuery::class:
-                $this->conn->getServer()->resetTable(
-                    $this->conn->getDatabaseName(),
-                    $parsed_query->table
-                );
+                [$databaseName, $tableName] = Processor\Processor::parseTableName($this->conn, $parsed_query->table);
+                $this->conn->getServer()->resetTable($databaseName, $tableName);
 
                 break;
 
             case Query\DropTableQuery::class:
-                $this->conn->getServer()->dropTable(
-                    $this->conn->getDatabaseName(),
-                    $parsed_query->table
-                );
+                [$databaseName, $tableName] = Processor\Processor::parseTableName($this->conn, $parsed_query->table);
+                $this->conn->getServer()->dropTable($databaseName, $tableName);
 
                 break;
 


### PR DESCRIPTION
Problem query `TRUNCATE 'db_name'.'table_name'` becomes `TRUNCATE 'connection-db-name'.'db_name.table_name'`, that also affects `DROP TABLE`.

Also fixed copy-paste issue in data-provider for Truncate-e2e unit-test.