### PR TITLE
Add PDO::quote() to FakePdoTrait

### DIFF
--- a/src/FakePdoTrait.php
+++ b/src/FakePdoTrait.php
@@ -164,4 +164,33 @@ trait FakePdoTrait
 
         return false;
     }
+
+    /**
+     * @param string $string
+     * @param int $parameter_type
+     * @return string
+     */
+    public function quote($string , $parameter_type = \PDO::PARAM_STR)
+    {
+        // @see https://github.com/php/php-src/blob/php-8.0.2/ext/mysqlnd/mysqlnd_charset.c#L860-L878
+        $quoted = strtr($string, [
+            "\0" => '\0',
+            "\n" => '\n',
+            "\r" => '\r',
+            "\\" => '\\\\',
+            "\'" => '\\\'',
+            "\"" => '\\"',
+            "\032" => '\Z',
+        ]);
+
+        // @see https://github.com/php/php-src/blob/php-8.0.2/ext/pdo_mysql/mysql_driver.c#L307-L320
+        $quotes = ['\'', '\''];
+        if (defined('PDO::PARAM_STR_NATL') &&
+            (constant('PDO::PARAM_STR_NATL') & $parameter_type) === constant('PDO::PARAM_STR_NATL')
+        ) {
+            $quotes[0] = 'N\'';
+        }
+
+        return "{$quotes[0]}{$quoted}{$quotes[1]}";
+    }
 }

--- a/tests/FakePdoTest.php
+++ b/tests/FakePdoTest.php
@@ -28,6 +28,32 @@ class FakePdoTest extends \PHPUnit\Framework\TestCase
         self::assertFalse($pdo->inTransaction());
     }
 
+    /**
+     * @dataProvider quotationStringProvider
+     */
+    public function testQuote(string $subject, string $expected): void
+    {
+        $pdo = self::getPdo('mysql:foo;dbname=test;');
+
+        self::assertSame($expected, $pdo->quote($subject));
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public function quotationStringProvider(): array
+    {
+        return [
+            'empty string' => ["", '\'\''],
+            'a' => ["a", '\'a\''],
+            'Kyoto in Chinese character' => ["京都", '\'京都\''],
+            'null character' => ["\0", '\'\0\''],
+            'includes newline(LF)'=> ["\na\nb", '\'\na\nb\''],
+            'includes newline(CRLF)'=> ["\r\na\r\nb", '\'\r\na\r\nb\''],
+            'includes quotations'=> ["\'a\"b", '\'\\\'a\\"b\''],
+            'includes ascii 032(\Z)' => [implode(['a', chr(032), 'b']), '\'a\Zb\''],
+        ];
+    }
 
     private static function getPdo(string $connection_string, bool $strict_mode = false) : \PDO
     {


### PR DESCRIPTION
Implement [`PDO::quote()`](https://www.php.net/manual/en/pdo.quote.php).

## Why

We maintain [a SQL template engine](https://github.com/BaguettePHP/TetoSQL) that depends on escaping with `PDO::quote()`.
Currently we have this method in a class that inherits from `FakePdo`.