### PR TITLE
Supports SHOW INDEX syntax

### DIFF
--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -243,6 +243,10 @@ trait FakePdoStatementTrait
 
                 break;
 
+            case Query\ShowIndexQuery::class:
+                $this->result = Processor\ShowIndexProcessor::process($this->conn, $parsed_query->table);
+                break;
+
             default:
                 throw new \UnexpectedValueException('Unsupported operation type ' . $sql);
         }

--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -244,7 +244,14 @@ trait FakePdoStatementTrait
                 break;
 
             case Query\ShowIndexQuery::class:
-                $this->result = Processor\ShowIndexProcessor::process($this->conn, $parsed_query->table);
+                $this->result = self::processResult(
+                    $this->conn,
+                    Processor\ShowIndexProcessor::process(
+                        $this->conn,
+                        new Processor\Scope(array_merge($params ?? [], $this->boundValues)),
+                        $parsed_query
+                    )
+                );
                 break;
 
             default:

--- a/src/Parser/SQLParser.php
+++ b/src/Parser/SQLParser.php
@@ -2,15 +2,14 @@
 namespace Vimeo\MysqlEngine\Parser;
 
 use Vimeo\MysqlEngine\TokenType;
-use Vimeo\MysqlEngine\Query\{
-    SelectQuery,
+use Vimeo\MysqlEngine\Query\{SelectQuery,
     DeleteQuery,
+    ShowIndexQuery,
     TruncateQuery,
     InsertQuery,
     UpdateQuery,
     DropTableQuery,
-    ShowTablesQuery
-};
+    ShowTablesQuery};
 
 final class SQLParser
 {
@@ -142,10 +141,11 @@ final class SQLParser
         'TABLES' => true,
     ];
 
+    /** @var array<SelectQuery|InsertQuery|UpdateQuery|TruncateQuery|DeleteQuery|DropTableQuery|ShowTablesQuery|ShowIndexQuery> */
     private static $cache = [];
 
     /**
-     * @return SelectQuery|InsertQuery|UpdateQuery|TruncateQuery|DeleteQuery|DropTableQuery|ShowTablesQuery
+     * @return SelectQuery|InsertQuery|UpdateQuery|TruncateQuery|DeleteQuery|DropTableQuery|ShowTablesQuery|ShowIndexQuery
      */
     public static function parse(string $sql)
     {
@@ -157,7 +157,7 @@ final class SQLParser
     }
 
     /**
-     * @return SelectQuery|InsertQuery|UpdateQuery|TruncateQuery|DeleteQuery|DropTableQuery|ShowTablesQuery
+     * @return SelectQuery|InsertQuery|UpdateQuery|TruncateQuery|DeleteQuery|DropTableQuery|ShowTablesQuery|ShowIndexQuery
      */
     private static function parseImpl(string $sql)
     {

--- a/src/Parser/ShowParser.php
+++ b/src/Parser/ShowParser.php
@@ -88,7 +88,7 @@ final class ShowParser
         }
         $this->pointer++;
         $token = $this->tokens[$this->pointer];
-        if ($token === null || $token->type !== TokenType::IDENTIFIER) {
+        if ($token->type !== TokenType::IDENTIFIER) {
             throw new ParserException("Expected table name after FROM");
         }
 

--- a/src/Processor/ShowIndexProcessor.php
+++ b/src/Processor/ShowIndexProcessor.php
@@ -5,41 +5,53 @@ namespace Vimeo\MysqlEngine\Processor;
 
 
 use Vimeo\MysqlEngine\FakePdoInterface;
+use Vimeo\MysqlEngine\Query\ShowIndexQuery;
+use Vimeo\MysqlEngine\Schema\Column;
 
 class ShowIndexProcessor extends Processor
 {
     public static function process(
         FakePdoInterface $conn,
-        string $table
-    ): array
-    {
-        $result = [];
-        [$database, $table] = Processor::parseTableName($conn, $table);
+        Scope $scope,
+        ShowIndexQuery $stmt
+    ): QueryResult {
+        [$database, $table] = Processor::parseTableName($conn, $stmt->table);
         $table_definition = $conn->getServer()->getTableDefinition(
             $database,
             $table
         );
+        $columns = [
+            'Table' => new Column\Varchar(255),
+            'Non_unique' => new Column\TinyInt(true, 1),
+            'Key_name' => new Column\Varchar(255),
+            'Seq_in_index' => new Column\intColumn(true, 4),
+            'Column_name' => new Column\Varchar(255),
+            'Collation' => new Column\Char(1),
+            'Cardinality' => new Column\intColumn(true, 4),
+            'Sub_part' => new Column\intColumn(true, 4),
+            'Packed' => new Column\TinyInt(true, 1),
+            'Null' => new Column\Varchar(3),
+            'Index_type' => new Column\Varchar(5),
+            'Comment' => new Column\Varchar(255),
+            'Index_comment' => new Column\Varchar(255)
+        ];
+        $rows = [];
         foreach ($table_definition->indexes as $name => $index) {
             foreach ($index->columns as $i => $column) {
-                $result[] = [
+                $rows[] = [
                     'Table' => $table_definition->name,
                     'Non_unique' => $index->type === 'INDEX' ? 1 : 0,
                     'Key_name' => $name,
-                    'Seq_in_index' => $i+1,
+                    'Seq_in_index' => $i + 1,
                     'Column_name' => $column,
+                    // Index には "direction" がない(CreateIndex の $cols にはある)ため null
+                    'Collation' => null,
                     /*
-                     * https://dev.mysql.com/doc/refman/5.6/ja/create-index.html
-                     * index_col_name の指定を ASC または DESC で終了させることができます。
-                     * これらのキーワードは、インデックス値の昇順または降順での格納を指定する将来の拡張のために許可されています。
-                     * 現在、これらは解析されますが、無視されます。インデックス値は、常に昇順で格納されます。
-                     */
-                    'Collation' => 'A',
-                    /*
-                     * https://dev.mysql.com/doc/refman/5.6/ja/analyze-table.html
+                     * https://dev.mysql.com/doc/refman/8.0/en/analyze-table.html
                      * ANALYZE TABLE が未実装のため null
                      */
                     'Cardinality' => null,
-                    //  Index には "length" がない(CreateIndex の $cols にはある)ため null
+                    // Index には "length" がない(CreateIndex の $cols にはある)ため null
                     'Sub_part' => null,
                     // PACK_KEYS が未実装のため null
                     'Packed' => null,
@@ -53,6 +65,7 @@ class ShowIndexProcessor extends Processor
                 ];
             }
         }
-        return $result;
+        $result = self::applyWhere($conn, $scope, $stmt->whereClause, new QueryResult($rows, $columns));
+        return new QueryResult(array_merge($result->rows), $result->columns);
     }
 }

--- a/src/Processor/ShowIndexProcessor.php
+++ b/src/Processor/ShowIndexProcessor.php
@@ -44,23 +44,23 @@ class ShowIndexProcessor extends Processor
                     'Key_name' => $name,
                     'Seq_in_index' => $i + 1,
                     'Column_name' => $column,
-                    // Index には "direction" がない(CreateIndex の $cols にはある)ため null
+                    // because Index does not have "direction" (in the $cols of CreateIndex)
                     'Collation' => null,
                     /*
                      * https://dev.mysql.com/doc/refman/8.0/en/analyze-table.html
-                     * ANALYZE TABLE が未実装のため null
+                     * because ANALYZE TABLE is not implemented
                      */
                     'Cardinality' => null,
-                    // Index には "length" がない(CreateIndex の $cols にはある)ため null
+                    // because Index does not have "length" (in the $cols of CreateIndex)
                     'Sub_part' => null,
-                    // PACK_KEYS が未実装のため null
+                    // because PACK_KEYS is not implemented
                     'Packed' => null,
                     'Null' => $table_definition->columns[$column]->isNullable ? 'YES' : '',
-                    // Index には $mode がない(CreateIndex にはある)ため null
+                    // because Index does not have $mode (in the CreateIndex)
                     'Index_type' => null,
-                    // DISABLE KEYS 未実装のため ''
+                    // because DISABLE KEYS is not implemented
                     'Comment' => '',
-                    // CREATE TABLE の INDEX COMMENT がスキップされているので ''
+                    // because INDEX COMMENT is skipped in CREATE TABLE
                     'Index_comment' => ''
                 ];
             }

--- a/src/Processor/ShowIndexProcessor.php
+++ b/src/Processor/ShowIndexProcessor.php
@@ -1,0 +1,58 @@
+<?php
+
+
+namespace Vimeo\MysqlEngine\Processor;
+
+
+use Vimeo\MysqlEngine\FakePdoInterface;
+
+class ShowIndexProcessor extends Processor
+{
+    public static function process(
+        FakePdoInterface $conn,
+        string $table
+    ): array
+    {
+        $result = [];
+        [$database, $table] = Processor::parseTableName($conn, $table);
+        $table_definition = $conn->getServer()->getTableDefinition(
+            $database,
+            $table
+        );
+        foreach ($table_definition->indexes as $name => $index) {
+            foreach ($index->columns as $i => $column) {
+                $result[] = [
+                    'Table' => $table_definition->name,
+                    'Non_unique' => $index->type === 'INDEX' ? 1 : 0,
+                    'Key_name' => $name,
+                    'Seq_in_index' => $i+1,
+                    'Column_name' => $column,
+                    /*
+                     * https://dev.mysql.com/doc/refman/5.6/ja/create-index.html
+                     * index_col_name の指定を ASC または DESC で終了させることができます。
+                     * これらのキーワードは、インデックス値の昇順または降順での格納を指定する将来の拡張のために許可されています。
+                     * 現在、これらは解析されますが、無視されます。インデックス値は、常に昇順で格納されます。
+                     */
+                    'Collation' => 'A',
+                    /*
+                     * https://dev.mysql.com/doc/refman/5.6/ja/analyze-table.html
+                     * ANALYZE TABLE が未実装のため null
+                     */
+                    'Cardinality' => null,
+                    //  Index には "length" がない(CreateIndex の $cols にはある)ため null
+                    'Sub_part' => null,
+                    // PACK_KEYS が未実装のため null
+                    'Packed' => null,
+                    'Null' => $table_definition->columns[$column]->isNullable ? 'YES' : '',
+                    // Index には $mode がない(CreateIndex にはある)ため null
+                    'Index_type' => null,
+                    // DISABLE KEYS 未実装のため ''
+                    'Comment' => '',
+                    // CREATE TABLE の INDEX COMMENT がスキップされているので ''
+                    'Index_comment' => ''
+                ];
+            }
+        }
+        return $result;
+    }
+}

--- a/src/Processor/ShowIndexProcessor.php
+++ b/src/Processor/ShowIndexProcessor.php
@@ -7,6 +7,7 @@ namespace Vimeo\MysqlEngine\Processor;
 use Vimeo\MysqlEngine\FakePdoInterface;
 use Vimeo\MysqlEngine\Query\ShowIndexQuery;
 use Vimeo\MysqlEngine\Schema\Column;
+use function PHPUnit\Framework\assertIsArray;
 
 class ShowIndexProcessor extends Processor
 {
@@ -20,15 +21,18 @@ class ShowIndexProcessor extends Processor
             $database,
             $table
         );
+        if (!$table_definition) {
+            return new QueryResult([], []);
+        }
         $columns = [
             'Table' => new Column\Varchar(255),
             'Non_unique' => new Column\TinyInt(true, 1),
             'Key_name' => new Column\Varchar(255),
-            'Seq_in_index' => new Column\intColumn(true, 4),
+            'Seq_in_index' => new Column\IntColumn(true, 4),
             'Column_name' => new Column\Varchar(255),
             'Collation' => new Column\Char(1),
-            'Cardinality' => new Column\intColumn(true, 4),
-            'Sub_part' => new Column\intColumn(true, 4),
+            'Cardinality' => new Column\IntColumn(true, 4),
+            'Sub_part' => new Column\IntColumn(true, 4),
             'Packed' => new Column\TinyInt(true, 1),
             'Null' => new Column\Varchar(3),
             'Index_type' => new Column\Varchar(5),
@@ -42,7 +46,7 @@ class ShowIndexProcessor extends Processor
                     'Table' => $table_definition->name,
                     'Non_unique' => $index->type === 'INDEX' ? 1 : 0,
                     'Key_name' => $name,
-                    'Seq_in_index' => $i + 1,
+                    'Seq_in_index' => 1 + (int) $i,
                     'Column_name' => $column,
                     // because Index does not have "direction" (in the $cols of CreateIndex)
                     'Collation' => null,

--- a/src/Query/ShowIndexQuery.php
+++ b/src/Query/ShowIndexQuery.php
@@ -4,6 +4,11 @@ namespace Vimeo\MysqlEngine\Query;
 final class ShowIndexQuery
 {
     /**
+     * @var ?Expression
+     */
+    public $whereClause = null;
+
+    /**
      * @var string
      */
     public $table;

--- a/src/Query/ShowIndexQuery.php
+++ b/src/Query/ShowIndexQuery.php
@@ -1,0 +1,21 @@
+<?php
+namespace Vimeo\MysqlEngine\Query;
+
+final class ShowIndexQuery
+{
+    /**
+     * @var string
+     */
+    public $table;
+
+    /**
+     * @var string
+     */
+    public $sql;
+
+    public function __construct(string $table, string $sql)
+    {
+        $this->table = $table;
+        $this->sql = $sql;
+    }
+}

--- a/src/Query/ShowIndexQuery.php
+++ b/src/Query/ShowIndexQuery.php
@@ -1,6 +1,8 @@
 <?php
 namespace Vimeo\MysqlEngine\Query;
 
+use Vimeo\MysqlEngine\Query\Expression\Expression;
+
 final class ShowIndexQuery
 {
     /**

--- a/src/Schema/Index.php
+++ b/src/Schema/Index.php
@@ -9,12 +9,13 @@ class Index
     public $type;
 
     /**
-     * @var array
+     * @var array<string>
      */
     public $columns;
 
     /**
      * @param 'INDEX'|'UNIQUE'|'PRIMARY'|'FULLTEXT'|'SPATIAL' $type
+     * @param array<string> $columns
      */
     public function __construct(
         string $type,

--- a/tests/ShowIndexParseTest.php
+++ b/tests/ShowIndexParseTest.php
@@ -1,0 +1,35 @@
+<?php
+namespace Vimeo\MysqlEngine\Tests;
+
+class ShowIndexParseTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSimpleParse()
+    {
+        $query = 'SHOW INDEX FROM foo';
+
+        $show_query = \Vimeo\MysqlEngine\Parser\SQLParser::parse($query);
+
+        $this->assertInstanceOf(\Vimeo\MysqlEngine\Query\ShowIndexQuery::class, $show_query);
+        $this->assertSame('foo', $show_query->table);
+    }
+
+    public function testIndexesParse()
+    {
+        $query = 'SHOW INDEXES FROM foo';
+
+        $show_query = \Vimeo\MysqlEngine\Parser\SQLParser::parse($query);
+
+        $this->assertInstanceOf(\Vimeo\MysqlEngine\Query\ShowIndexQuery::class, $show_query);
+        $this->assertSame('foo', $show_query->table);
+    }
+
+    public function testKeysParse()
+    {
+        $query = 'SHOW KEYS FROM foo';
+
+        $show_query = \Vimeo\MysqlEngine\Parser\SQLParser::parse($query);
+
+        $this->assertInstanceOf(\Vimeo\MysqlEngine\Query\ShowIndexQuery::class, $show_query);
+        $this->assertSame('foo', $show_query->table);
+    }
+}

--- a/tests/ShowIndexParseTest.php
+++ b/tests/ShowIndexParseTest.php
@@ -1,35 +1,63 @@
 <?php
+
 namespace Vimeo\MysqlEngine\Tests;
 
-class ShowIndexParseTest extends \PHPUnit\Framework\TestCase
+use PHPUnit\Framework\TestCase;
+use Vimeo\MysqlEngine\Parser\SQLParser;
+use Vimeo\MysqlEngine\Query\SelectQuery;
+use Vimeo\MysqlEngine\Query\ShowIndexQuery;
+
+class ShowIndexParseTest extends TestCase
 {
     public function testSimpleParse()
     {
-        $query = 'SHOW INDEX FROM foo';
+        $query = 'SHOW INDEX FROM `foo`';
 
-        $show_query = \Vimeo\MysqlEngine\Parser\SQLParser::parse($query);
+        $show_query = SQLParser::parse($query);
 
-        $this->assertInstanceOf(\Vimeo\MysqlEngine\Query\ShowIndexQuery::class, $show_query);
+        $this->assertInstanceOf(ShowIndexQuery::class, $show_query);
         $this->assertSame('foo', $show_query->table);
     }
 
     public function testIndexesParse()
     {
-        $query = 'SHOW INDEXES FROM foo';
+        $query = 'SHOW INDEXES FROM `foo`';
 
-        $show_query = \Vimeo\MysqlEngine\Parser\SQLParser::parse($query);
+        $show_query = SQLParser::parse($query);
 
-        $this->assertInstanceOf(\Vimeo\MysqlEngine\Query\ShowIndexQuery::class, $show_query);
+        $this->assertInstanceOf(ShowIndexQuery::class, $show_query);
         $this->assertSame('foo', $show_query->table);
     }
 
     public function testKeysParse()
     {
-        $query = 'SHOW KEYS FROM foo';
+        $query = 'SHOW KEYS FROM `foo`';
 
-        $show_query = \Vimeo\MysqlEngine\Parser\SQLParser::parse($query);
+        $show_query = SQLParser::parse($query);
 
-        $this->assertInstanceOf(\Vimeo\MysqlEngine\Query\ShowIndexQuery::class, $show_query);
+        $this->assertInstanceOf(ShowIndexQuery::class, $show_query);
         $this->assertSame('foo', $show_query->table);
     }
+
+    public function testParseInvalid()
+    {
+        $query = 'SHOW INDEX FROM `foo';
+
+        $this->expectException(\Vimeo\MysqlEngine\Parser\LexerException::class);
+
+        $select_query = \Vimeo\MysqlEngine\Parser\SQLParser::parse($query);
+
+        $this->assertInstanceOf(SelectQuery::class, $select_query);
+    }
+
+    public function testWhereParse()
+    {
+        $query = "SHOW INDEX FROM `foo` WHERE `Key_name` = 'PRIMARY'";
+
+        $show_query = SQLParser::parse($query);
+
+        $this->assertInstanceOf(ShowIndexQuery::class, $show_query);
+        $this->assertSame('foo', $show_query->table);
+    }
+
 }


### PR DESCRIPTION
Implement [SHOW INDEX](https://dev.mysql.com/doc/refman/8.0/en/show-index.html) syntax.
Set null for columns that depend on unimplemented processing.
A value that is set to CreateIndex but not set to Index is set to null for the time being. Since `Index->$column` is a string array, it is necessary to change the type, and it was expected that the scale would increase.