### PR TITLE
Set default fetch style

### DIFF
--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -26,7 +26,7 @@ trait FakePdoStatementTrait
     /**
      * @var int
      */
-    private $fetchMode = \PDO::ATTR_DEFAULT_FETCH_MODE;
+    private $fetchMode = \PDO::FETCH_BOTH;
 
     private $fetchArgument;
 

--- a/src/FakePdoTrait.php
+++ b/src/FakePdoTrait.php
@@ -73,7 +73,10 @@ trait FakePdoTrait
             $this->lowercaseResultKeys = true;
         }
 
-        if ($key === \PDO::ATTR_DEFAULT_FETCH_MODE && is_int($value)) {
+        if ($key === \PDO::ATTR_DEFAULT_FETCH_MODE) {
+            if (!is_int($value)) {
+                throw new \PDOException("SQLSTATE[HY000]: General error: invalid fetch mode type");
+            }
             $this->defaultFetchMode = $value;
         }
 

--- a/src/FakePdoTrait.php
+++ b/src/FakePdoTrait.php
@@ -29,7 +29,7 @@ trait FakePdoTrait
     public $lowercaseResultKeys = false;
 
     /** @var ?int */
-    private $default_fetch_mode = null;
+    private $defaultFetchMode = null;
 
     /**
      * @var bool
@@ -74,7 +74,7 @@ trait FakePdoTrait
         }
 
         if ($key === \PDO::ATTR_DEFAULT_FETCH_MODE && is_int($value)) {
-            $this->default_fetch_mode = $value;
+            $this->defaultFetchMode = $value;
         }
 
         if ($this->real && $key !== \PDO::ATTR_STATEMENT_CLASS) {

--- a/src/FakePdoTrait.php
+++ b/src/FakePdoTrait.php
@@ -28,6 +28,9 @@ trait FakePdoTrait
      */
     public $lowercaseResultKeys = false;
 
+    /** @var ?int */
+    private $default_fetch_mode = null;
+
     /**
      * @var bool
      */
@@ -68,6 +71,10 @@ trait FakePdoTrait
 
         if ($key === \PDO::ATTR_CASE && $value === \PDO::CASE_LOWER) {
             $this->lowercaseResultKeys = true;
+        }
+
+        if ($key === \PDO::ATTR_DEFAULT_FETCH_MODE && is_int($value)) {
+            $this->default_fetch_mode = $value;
         }
 
         if ($this->real && $key !== \PDO::ATTR_STATEMENT_CLASS) {

--- a/src/Php7/FakePdo.php
+++ b/src/Php7/FakePdo.php
@@ -17,8 +17,8 @@ class FakePdo extends PDO implements FakePdoInterface
     public function prepare($statement, $options = [])
     {
         $stmt = new FakePdoStatement($this, $statement, $this->real);
-        if ($this->default_fetch_mode) {
-            $stmt->setFetchMode($this->default_fetch_mode);
+        if ($this->defaultFetchMode) {
+            $stmt->setFetchMode($this->defaultFetchMode);
         }
         return $stmt;
     }

--- a/src/Php7/FakePdo.php
+++ b/src/Php7/FakePdo.php
@@ -16,7 +16,11 @@ class FakePdo extends PDO implements FakePdoInterface
      */
     public function prepare($statement, $options = [])
     {
-        return new FakePdoStatement($this, $statement, $this->real);
+        $stmt = new FakePdoStatement($this, $statement, $this->real);
+        if ($this->default_fetch_mode) {
+            $stmt->setFetchMode($this->default_fetch_mode);
+        }
+        return $stmt;
     }
 
     /**


### PR DESCRIPTION
PDO::ATTR_DEFAULT_FETCH_MODE is the key for setAttribute, not fetch_style. (https://www.php.net/manual/en/pdo.setattribute.php)
The default for fetch_style is PDO::FETCH_BOTH, so set it.
(https://www.php.net/manual/en/pdostatement.fetch.php)
And I made it possible to set DEFAULT_FETCH_MODE with setAttribute.
This allows we to omit the fetch argument.