### PR TITLE
Add support for FETCH_COLUMN in fetch

### DIFF
--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -336,6 +336,12 @@ trait FakePdoStatementTrait
             return \array_values($row);
         }
 
+        if ($fetch_style === \PDO::FETCH_COLUMN) {
+            $this->resultCursor++;
+
+            return \array_values($row)[0] ?? null;
+        }
+
         if ($fetch_style === \PDO::FETCH_BOTH) {
             $this->resultCursor++;
 

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -901,6 +901,17 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         $query->fetchColumn($columnIndex);
     }
 
+    public function testFetchWithColumnMode()
+    {
+        $pdo = self::getConnectionToFullDB(false);
+
+        $query = $pdo->prepare('SELECT `id` FROM `video_game_characters` WHERE id=2 LIMIT 1');
+
+        $query->execute();
+
+        self::assertEquals(2, $query->fetch(\PDO::FETCH_COLUMN));
+    }
+
     public function dataProviderTruncateForms(): \Generator
     {
         foreach ([


### PR DESCRIPTION
This PR adds support for `\PDO::FETCH_COLUMN` fetch style in `FakePdoStatementTrait::fetch`.

It fixes usage of `\Doctrine\DBAL\Connection::fetchOne`