### PR TITLE
Fix: MySQL function ROUND() can take 1 or 2 arguments.

### DIFF
--- a/src/Processor/Expression/FunctionEvaluator.php
+++ b/src/Processor/Expression/FunctionEvaluator.php
@@ -2,10 +2,11 @@
 namespace Vimeo\MysqlEngine\Processor\Expression;
 
 use Vimeo\MysqlEngine\FakePdoInterface;
+use Vimeo\MysqlEngine\Processor\ProcessorException;
 use Vimeo\MysqlEngine\Processor\QueryResult;
 use Vimeo\MysqlEngine\Processor\Scope;
-use Vimeo\MysqlEngine\Processor\ProcessorException;
 use Vimeo\MysqlEngine\Query\Expression\ColumnExpression;
+use Vimeo\MysqlEngine\Query\Expression\ConstantExpression;
 use Vimeo\MysqlEngine\Query\Expression\Expression;
 use Vimeo\MysqlEngine\Query\Expression\FunctionExpression;
 use Vimeo\MysqlEngine\Query\Expression\IntervalOperatorExpression;
@@ -226,6 +227,19 @@ final class FunctionEvaluator
                 return Evaluator::getColumnSchema($expr->args[0], $scope, $columns);
 
             case 'ROUND':
+                $precision = 0;
+
+                if (isset($expr->args[1])) {
+                    /** @var ConstantExpression $arg */
+                    $arg = $expr->args[1];
+
+                    $precision = (int)$arg->value;
+                }
+
+                if ($precision === 0) {
+                    return new Column\IntColumn(false, 10);
+                }
+
                 return Evaluator::getColumnSchema($expr->args[0], $scope, $columns);
 
             case 'DATEDIFF':
@@ -1186,6 +1200,8 @@ final class FunctionEvaluator
 
     /**
      * @param array<string, mixed> $row
+     *
+     * @return float|int
      */
     private static function sqlRound(
         FakePdoInterface $conn,
@@ -1193,17 +1209,22 @@ final class FunctionEvaluator
         FunctionExpression $expr,
         array $row,
         QueryResult $result
-    ) : float {
+    ) {
         $args = $expr->args;
 
-        if (\count($args) !== 2) {
-            throw new ProcessorException("MySQL ROUND() function must be called with one arguments");
+        if (\count($args) !== 1 && \count($args) !== 2) {
+            throw new ProcessorException("MySQL ROUND() function must be called with one or two arguments");
         }
 
-        $first = Evaluator::evaluate($conn, $scope, $args[0], $row, $result);
-        $second = Evaluator::evaluate($conn, $scope, $args[1], $row, $result);
+        $number = (float)Evaluator::evaluate($conn, $scope, $args[0], $row, $result);
 
-        return \round($first, $second);
+        if (!isset($args[1])) {
+            return \round($number);
+        }
+
+        $precision = (int)Evaluator::evaluate($conn, $scope, $args[1], $row, $result);
+
+        return \round($number, $precision);
     }
 
     private static function getPhpIntervalFromExpression(

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -522,6 +522,26 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testRound()
+    {
+        $pdo = self::getPdo('mysql:foo');
+        $pdo->setAttribute(\PDO::ATTR_EMULATE_PREPARES, false);
+
+        $query = $pdo->prepare('SELECT ROUND(3.141592) AS a, ROUND(3.141592, 2) AS b');
+
+        $query->execute();
+
+        $this->assertSame(
+            [
+                [
+                    'a' => 3,
+                    'b' => 3.14,
+                ],
+            ],
+            $query->fetchAll(\PDO::FETCH_ASSOC)
+        );
+    }
+
     public function testIsInFullSubquery()
     {
         $pdo = self::getConnectionToFullDB(false);


### PR DESCRIPTION
MySQL function [ROUND()](https://dev.mysql.com/doc/refman/5.6/en/mathematical-functions.html#function_round) can take 1 or 2 arguments. Second argument defaults to 0 if not specified.