### PR TITLE
Stub errorInfo() to prevent upstream issues

### DIFF
--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -601,4 +601,9 @@ trait FakePdoStatementTrait
 
         return $sql;
     }
+
+    public function errorInfo(): array
+    {
+        return ['00000', 0, 'PHP MySQL Engine: errorInfo() not supported.'];
+    }
 }

--- a/src/FakePdoTrait.php
+++ b/src/FakePdoTrait.php
@@ -212,4 +212,9 @@ trait FakePdoTrait
 
         return "{$quotes[0]}{$quoted}{$quotes[1]}";
     }
+
+    public function errorInfo(): array
+    {
+        return ['00000', 0, 'PHP MySQL Engine: errorInfo() not supported.'];
+    }
 }


### PR DESCRIPTION
The library is written for exception error handling (which is fine), but if any code treats it as generic PDO and calls `errorInfo()` things fall apart:
1. Native PDO code barfs rather annoying `No error: PDO constructor was not called` warning, that isn't easy to work around.
2. The return is `null`, rather than supposed three fields array structure.

Since the any _real_ error would be an exception anyway, I stubbed the methods to hardcode a no-error state for anything that asks.

Not confident that is _the_ way to go about it, but don't have a better idea. Open to explore alternative takes if there are any pointers. :)