### PR TITLE
Fix a warning when DateTime column has empty value

### DIFF
--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -215,7 +215,7 @@ final class DataIntegrity
                         $value .= ' 00:00:00';
                     }
 
-                    if ($value[0] === '-' || $value === '') {
+                    if ($value === '' || $value[0] === '-') {
                         $value = '0000-00-00 00:00:00';
                     } elseif (\preg_match(
                         '/^([0-9]{2,4}-[0-1][0-9]-[0-3][0-9]|[0-9]+)$/',

--- a/tests/DataIntegrityTest.php
+++ b/tests/DataIntegrityTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Vimeo\MysqlEngine\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Vimeo\MysqlEngine\DataIntegrity;
+use Vimeo\MysqlEngine\FakePdoInterface;
+use Vimeo\MysqlEngine\Php7\FakePdo;
+use Vimeo\MysqlEngine\Schema\Column\DateTime;
+use const PHP_MAJOR_VERSION;
+
+class DataIntegrityTest extends TestCase
+{
+
+    public function testEmptyDateTimeColumnShouldReturnDefaultDate()
+    {
+        $dateTimeColumn = new DateTime();
+
+        $result = DataIntegrity::coerceValueToColumn($this->getPdo(), $dateTimeColumn, '');
+
+        $this->assertEquals('0000-00-00 00:00:00', $result);
+    }
+
+    private static function getPdo(): FakePdoInterface
+    {
+        if (PHP_MAJOR_VERSION === 8) {
+            return new \Vimeo\MysqlEngine\Php8\FakePdo('mysql:foo;dbname=test;');
+        }
+
+        return new FakePdo('mysql:foo;dbname=test;');
+    }
+}


### PR DESCRIPTION
Dear reviewer,

When you have a DateTime column and the value is empty a warning was raised.

The code first checks the string at position 0 then check if is "empty".

On PHP version <= 7.4 A warning is raised if you try to access [0] of an "Uninitialized" string and `$foo = ''` is an "Uninitialized" string 🤷‍♂️ .

(I haven't check if this behavior still exists on PHP >=8.0).

The change is just a small change in the order of an existing code.