### PR TITLE
feat(UNIX_TIMESTAMP): add basic support for UNIX_TIMESTAMP function

### DIFF
--- a/src/Processor/Expression/FunctionEvaluator.php
+++ b/src/Processor/Expression/FunctionEvaluator.php
@@ -71,6 +71,8 @@ final class FunctionEvaluator
                 return self::sqlBinary($conn, $scope, $expr, $row, $result);
             case 'FROM_UNIXTIME':
                 return self::sqlFromUnixtime($conn, $scope, $expr, $row, $result);
+            case 'UNIX_TIMESTAMP':
+                return self::sqlUnixTimestamp($conn, $scope, $expr, $row, $result);
             case 'GREATEST':
                 return self::sqlGreatest($conn, $scope, $expr, $row, $result);
             case 'VALUES':
@@ -843,6 +845,32 @@ final class FunctionEvaluator
         $column = Evaluator::evaluate($conn, $scope, $args[0], $row, $result);
 
         return \date('Y-m-d H:i:s', (int) $column);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function sqlUnixTimestamp(
+        FakePdoInterface $conn,
+        Scope $scope,
+        FunctionExpression $expr,
+        array $row,
+        QueryResult $result
+    ) : ?int {
+        $args = $expr->args;
+
+        switch (\count($args)) {
+            case 0:
+                return time();
+            case 1:
+                $column = Evaluator::evaluate($conn, $scope, $args[0], $row, $result);
+                if (!\is_string($column)) {
+                    return null;
+                }
+                return \strtotime($column) ?: null;
+            default:
+                throw new ProcessorException("MySQL UNIX_TIMESTAPM() SQLFake only implemented for 0 or 1 argument");
+        }
     }
 
     /**


### PR DESCRIPTION
Added basic support for `UNIX_TIMESTAMP()` function:

- without arguments: returns current timestamp
- with single argument: transforms string representation of date/datetime to timestamp

Things could be done:
 - add some checks for invalid values/formats
 - add support for timezones
 - support for floating point type of return value
   ```
   mysql> SELECT UNIX_TIMESTAMP('2015-11-13 10:20:19.012');
       -> 1447431619.012
   ```

Docs for function - [MySQL 8.0 Reference Manual](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_unix-timestamp)