### PR TITLE
Support empty date

### DIFF
--- a/src/DataIntegrity.php
+++ b/src/DataIntegrity.php
@@ -228,7 +228,7 @@ final class DataIntegrity
                 if ($column instanceof Schema\Column\Date) {
                     if (\strlen($value) === 19) {
                         $value = \substr($value, 0, 10);
-                    } elseif ($value[0] === '-' || $value === '') {
+                    } elseif ($value === '' || $value[0] === '-') {
                         $value = '0000-00-00';
                     } elseif (\preg_match('/^[0-9]+$/', (string) $value)) {
                         $value = (new \DateTime($value))->format('Y-m-d');


### PR DESCRIPTION
When `$value` is an empty string then accessing its first element (`$value[0]`) fails:

```
Uninitialized string offset: 0
```