### PR TITLE
Fix field support for CHARACTER SET & COLLATE

### DIFF
--- a/src/Processor/CreateProcessor.php
+++ b/src/Processor/CreateProcessor.php
@@ -277,8 +277,8 @@ final class CreateProcessor
      */
     private static function getTextDefinitionColumn(Query\MysqlColumnType $stmt)
     {
-        $collation = null;
-        $character_set = null;
+        $collation = $stmt->collation;
+        $character_set = $stmt->character_set;
 
         switch (strtoupper($stmt->type)) {
             case DataType::TEXT:

--- a/src/Schema/Column/CharacterColumn.php
+++ b/src/Schema/Column/CharacterColumn.php
@@ -69,9 +69,8 @@ abstract class CharacterColumn extends \Vimeo\MysqlEngine\Schema\Column
 
         return '(new \\' . static::class . '('
             . $this->max_string_length
-            . ($this->character_set !== null && $this->collation !== null
-                ? ', \'' . $this->character_set . '\'' . ', \'' . $this->collation . '\''
-                : '')
+            . ($this->character_set !== null ? ', \'' . $this->character_set . '\'' : '')
+            . ($this->collation !== null ? ', \'' . $this->collation . '\'' : '')
             . '))'
             . $default
             . $this->getNullablePhp();

--- a/tests/CreateTableParseTest.php
+++ b/tests/CreateTableParseTest.php
@@ -1,10 +1,9 @@
 <?php
 namespace Vimeo\MysqlEngine\Tests;
 
-use Vimeo\MysqlEngine\Query\SelectQuery;
-use Vimeo\MysqlEngine\Query\Expression\ColumnExpression;
-use Vimeo\MysqlEngine\Query\Expression\CaseOperatorExpression;
-use Vimeo\MysqlEngine\Query\Expression\BinaryOperatorExpression;
+use Vimeo\MysqlEngine\Parser\CreateTableParser;
+use Vimeo\MysqlEngine\Processor\CreateProcessor;
+use Vimeo\MysqlEngine\Schema\TableDefinition;
 
 class CreateTableParseTest extends \PHPUnit\Framework\TestCase
 {
@@ -12,21 +11,30 @@ class CreateTableParseTest extends \PHPUnit\Framework\TestCase
     {
         $query = file_get_contents(__DIR__ . '/fixtures/create_table.sql');
 
-        $create_queries = (new \Vimeo\MysqlEngine\Parser\CreateTableParser)->parse($query);
+        $create_queries = (new CreateTableParser)->parse($query);
 
-        $this->assertCount(5, $create_queries);
+        $this->assertNotEmpty($create_queries);
+
+        $table_defs = [];
 
         foreach ($create_queries as $create_query) {
-            $table = \Vimeo\MysqlEngine\Processor\CreateProcessor::makeTableDefinition(
+            $table = CreateProcessor::makeTableDefinition(
                 $create_query,
                 'foo'
             );
+            $table_defs[$table->name] = $table;
 
             $new_table_php_code = $table->getPhpCode();
 
             $new_table = eval('return ' . $new_table_php_code . ';');
 
-            $this->assertSame(\var_export($table, true), \var_export($new_table, true));
+            $this->assertSame(\var_export($table, true), \var_export($new_table, true),
+                "The table definition for {$table->name} did not match the generated php version.");
         }
+
+        // specific parsing checks
+        $this->assertInstanceOf(TableDefinition::class, $table_defs['tweets']);
+        $this->assertEquals('utf8mb4', $table_defs['tweets']->columns['text']->getCharacterSet());
+        $this->assertEquals('utf8mb4_unicode_ci', $table_defs['tweets']->columns['text']->getCollation());
     }
 }

--- a/tests/fixtures/create_table.sql
+++ b/tests/fixtures/create_table.sql
@@ -61,3 +61,10 @@ CREATE TABLE `orders`
 	`modified_on` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (`id`)
 )ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+CREATE TABLE `tweets` (
+	`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+	`text` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	PRIMARY KEY (`id`)
+)
+ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;


### PR DESCRIPTION
Fixes two problems with `CHARACTER SET` & `COLLATE`

1. Neither  `CHARACTER SET` or `COLLATE` would actually be set properly on the resulting table definitions.
1. Both `CHARACTER SET` & `COLLATE` would be required for the `CharacterColumn::getPhpCode` to include it in php code generation
    * [According to the grammar][1], they can be used individually

Changes:
* `src/Processor/CreateProcessor.php` The change to `getTextDefinitionColumn` allows the values parsed from sql to be passed to `Column` generation functions.
* `src/Schema/Column/CharacterColumn.php` generate each function arg individually

Added an integration test to the create table parser just for an easy add (`CreateProcessor::getDefinitionColumn` is private)

[1]: https://dev.mysql.com/doc/refman/5.7/en/charset-column.html

cc @aaronm67 