### PR TITLE
fix text and char column php code args

### DIFF
--- a/src/Schema/Column/CharacterColumn.php
+++ b/src/Schema/Column/CharacterColumn.php
@@ -67,11 +67,13 @@ abstract class CharacterColumn extends \Vimeo\MysqlEngine\Schema\Column
             }
         }
 
-        return '(new \\' . static::class . '('
-            . $this->max_string_length
-            . ($this->character_set !== null ? ', \'' . $this->character_set . '\'' : '')
-            . ($this->collation !== null ? ', \'' . $this->collation . '\'' : '')
-            . '))'
+        $args = [
+            $this->max_string_length,
+            $this->character_set === null ? 'null' : "'{$this->character_set}'",
+            $this->collation === null ? 'null' : "'{$this->collation}'",
+        ];
+
+        return '(new \\' . static::class . '(' . implode(', ', $args) . '))'
             . $default
             . $this->getNullablePhp();
     }

--- a/src/Schema/Column/TextTrait.php
+++ b/src/Schema/Column/TextTrait.php
@@ -8,12 +8,13 @@ trait TextTrait
     public function getPhpCode() : string
     {
         $default = $this->getDefault() !== null ? '\'' . $this->getDefault() . '\'' : 'null';
-        
-        return '(new \\' . static::class . '('
-            . ($this->character_set !== null && $this->collation !== null
-                ? ', \'' . $this->character_set . '\'' . ', \'' . $this->collation . '\''
-                : '')
-            . '))'
+
+        $args = [
+            $this->character_set === null ? 'null' : "'{$this->character_set}'",
+            $this->collation === null ? 'null' : "'{$this->collation}'",
+        ];
+
+        return '(new \\' . static::class . '(' . implode(', ', $args) . '))'
             . ($this->hasDefault() ? '->setDefault(' . $default . ')' : '')
             . $this->getNullablePhp();
     }

--- a/tests/CreateTableParseTest.php
+++ b/tests/CreateTableParseTest.php
@@ -34,7 +34,17 @@ class CreateTableParseTest extends \PHPUnit\Framework\TestCase
 
         // specific parsing checks
         $this->assertInstanceOf(TableDefinition::class, $table_defs['tweets']);
+        $this->assertEquals('utf8mb4', $table_defs['tweets']->columns['title']->getCharacterSet());
+        $this->assertEquals('utf8mb4_unicode_ci', $table_defs['tweets']->columns['title']->getCollation());
         $this->assertEquals('utf8mb4', $table_defs['tweets']->columns['text']->getCharacterSet());
         $this->assertEquals('utf8mb4_unicode_ci', $table_defs['tweets']->columns['text']->getCollation());
+
+        $this->assertInstanceOf(TableDefinition::class, $table_defs['texts']);
+        $this->assertEquals('utf8mb4', $table_defs['texts']->columns['title_char_col']->getCharacterSet());
+        $this->assertEquals('utf8mb4_unicode_ci', $table_defs['texts']->columns['title_char_col']->getCollation());
+        $this->assertNull($table_defs['texts']->columns['title_col']->getCharacterSet());
+        $this->assertEquals('utf8mb4_unicode_ci', $table_defs['texts']->columns['title_col']->getCollation());
+        $this->assertNull($table_defs['texts']->columns['title']->getCharacterSet());
+        $this->assertNull($table_defs['texts']->columns['title']->getCollation());
     }
 }

--- a/tests/fixtures/create_table.sql
+++ b/tests/fixtures/create_table.sql
@@ -60,11 +60,25 @@ CREATE TABLE `orders`
 	`created_on`  timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	`modified_on` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (`id`)
-)ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+)
+ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 CREATE TABLE `tweets` (
 	`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
-	`text` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	`title` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	`text` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	PRIMARY KEY (`id`)
+)
+ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+CREATE TABLE `texts` (
+	`id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+	`title_char_col` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	`title_col` varchar(256) COLLATE utf8mb4_unicode_ci,
+	`title` varchar(256)
+	`text_char_col` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+	`text_col` text COLLATE utf8mb4_unicode_ci,
+	`text` text,
 	PRIMARY KEY (`id`)
 )
 ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;


### PR DESCRIPTION
https://github.com/vimeo/php-mysql-engine/pull/39 started setting `character_set` and `collation` properties which surfaced a problem that already existed in `src/Schema/Column/TextTrait.php`

A leading comma would be added to the generated constructor:
https://github.com/vimeo/php-mysql-engine/blob/2e8b092be2aaac4aea1551f9d493d1facda26773/src/Schema/Column/TextTrait.php#L14

Also noticed a potential bug in https://github.com/vimeo/php-mysql-engine/pull/39 in `CharacterColumn` arg building:
https://github.com/vimeo/php-mysql-engine/blob/21a606f3ef19d1ef7b9ab602117bea36a8c6e647/src/Schema/Column/CharacterColumn.php#L70-L76

If only `collation` was defined in that implementation, the value of `collation` would be used for the `character_set` argument in the constructor

This PR:
* just use a simple implode to always pass the number of args for CharacterColumn or TextColumn
* add a test table with each permutation of `test` and `varchar` `CHARACTER SET` and `COLLATE`