### PR TITLE
Fix a few PHP 8 related issues

### DIFF
--- a/src/Processor/Expression/BinaryOperatorEvaluator.php
+++ b/src/Processor/Expression/BinaryOperatorEvaluator.php
@@ -226,8 +226,18 @@ final class BinaryOperatorEvaluator
                     case 'MOD':
                         return \fmod((double) $left_number, (double) $right_number);
                     case '/':
+                        // Ensure division by 0 cannot occur and 0 divided by anything is also 0
+                        if ($right_number === 0 || $left_number === 0) {
+                            return 0;
+                        }
+
                         return $left_number / $right_number;
                     case 'DIV':
+                        // Ensure division by 0 cannot occur and 0 divided by anything is also 0
+                        if ($right_number === 0 || $left_number === 0) {
+                            return 0;
+                        }
+
                         return (int) ($left_number / $right_number);
                     case '-':
                         return $left_number - $right_number;

--- a/src/Processor/SelectProcessor.php
+++ b/src/Processor/SelectProcessor.php
@@ -301,7 +301,7 @@ final class SelectProcessor extends Processor
                             $parts = \explode(".%.", (string) $col);
 
                             if ($expr->tableName() !== null) {
-                                list($col_table_name, $col_name) = $parts;
+                                [$col_table_name, $col_name] = $parts;
                                 if ($col_table_name == $expr->tableName()) {
                                     if (!\array_key_exists($col, $formatted_row)) {
                                         $formatted_row[$col_name] = $val;
@@ -320,11 +320,15 @@ final class SelectProcessor extends Processor
                         continue;
                     }
 
+                    /**
+                     * Evaluator case \Vimeo\MysqlEngine\Query\Expression\SubqueryExpression::class:
+                     * should ensure the value of $val is never an array, and only the value of the
+                     * column requested, but we'll leave this code just to make sure of that.
+                     */
                     $val = Expression\Evaluator::evaluate($conn, $scope, $expr, $row, $group_result);
                     $name = $expr->name;
 
-                    if ($expr instanceof SubqueryExpression) {
-                        assert(\is_array($val), 'subquery results must be KeyedContainer');
+                    if ($expr instanceof SubqueryExpression && \is_array($val)) {
                         if (\count($val) > 1) {
                             throw new ProcessorException("Subquery returned more than one row");
                         }
@@ -477,7 +481,7 @@ final class SelectProcessor extends Processor
                     $parts = \explode(".", $column_id);
 
                     if ($expr_table_name = $expr->tableName()) {
-                        list($column_table_name) = $parts;
+                        [$column_table_name] = $parts;
 
                         if ($column_table_name === $expr_table_name) {
                             $columns[$column_id] = $from_column;


### PR DESCRIPTION
SelectProcessor.php expected the return value of `Evaluator` to be an array for the case where the expression is a `SubqueryExpression`, but `Evaluator` already ensures the value returned is the value of the column requested. Also removing assertion as it does nothing in a production environment and might be mistaken as a stopper to run the code.
BinaryOperatorEvaluator.php would blindly try to divide any right/left value by the other without checking for 0 first.