### PR TITLE
WIP: Add an UPDATE with ORDER BY that fails.

### DIFF
--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -1138,6 +1138,13 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testUpdateWithOrderAndPrimaryKey()
+    {
+        $pdo = self::getConnectionToFullDB(false);
+        $pdo->exec('UPDATE `video_game_characters` SET `bio_en` = "spiky boi" WHERE `id` = 7 ORDER BY `id` DESC LIMIT 1');
+    }
+
+
     private static function getPdo(string $connection_string, bool $strict_mode = false) : \PDO
     {
         $options = $strict_mode ? [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode="STRICT_ALL_TABLES"'] : [];

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -1141,7 +1141,7 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
     public function testUpdateWithOrderAndPrimaryKey()
     {
         $pdo = self::getConnectionToFullDB(false);
-        $pdo->exec('UPDATE `video_game_characters` SET `bio_en` = "spiky boi" WHERE `id` = 7 ORDER BY `id` DESC LIMIT 1');
+        $pdo->exec('UPDATE `video_game_characters` SET `bio_en` = "spiky boi" WHERE `id` = 7 ORDER BY `id` DESC');
     }
 
 


### PR DESCRIPTION
This PR demonstrates a corner case that we use in our code, where UPDATE is used with ORDER BY. I'm not sure how to resolve it, so it's a WIP.

The root cause is that ORDER BY causes the row index to reset in this statement:

```php
return new QueryResult(array_values($rows), $result->columns);
```

However, removing `array_values` causes errors in other tests!