### PR TITLE
fix: use default fetch mode for PHP8 PDO implementation

### DIFF
--- a/src/Php8/FakePdo.php
+++ b/src/Php8/FakePdo.php
@@ -17,7 +17,13 @@ class FakePdo extends PDO implements FakePdoInterface
     #[\ReturnTypeWillChange]
     public function prepare($statement, array $options = [])
     {
-        return new FakePdoStatement($this, $statement, $this->real);
+        $statement = new FakePdoStatement($this, $statement, $this->real);
+
+        if ($this->defaultFetchMode) {
+            $statement->setFetchMode($this->defaultFetchMode);
+        }
+
+        return $statement;
     }
 
     /**

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -34,6 +34,24 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         $this->assertSame([], $query->fetchAll(\PDO::FETCH_ASSOC));
     }
 
+    public function testSelectWithDefaultFetchAssoc()
+    {
+        $pdo = self::getConnectionToFullDB();
+        $pdo->setAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC);
+
+        $query = $pdo->prepare("SELECT id FROM `video_game_characters` WHERE `id` > :id ORDER BY `id` ASC");
+        $query->bindValue(':id', 14);
+        $query->execute();
+
+        $this->assertSame(
+            [
+                ['id' => '15'],
+                ['id' => '16']
+            ],
+            $query->fetchAll()
+        );
+    }
+
     public function testSelectFetchAssoc()
     {
         $pdo = self::getConnectionToFullDB();


### PR DESCRIPTION
This is a copy of the changes from #15 (0e864b2), making the two versions of `FakePdo` behave the same WRT respecting `->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, *)`.

Made sure to add an appropriate test.