### PR TITLE
fix: correctly handle the default `::fetch` style for statements

### DIFF
--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -339,7 +339,7 @@ trait FakePdoStatementTrait
         $cursor_orientation = \PDO::FETCH_ORI_NEXT,
         $cursor_offset = 0
     ) {
-        if ($fetch_style === -123) {
+        if ($fetch_style === -123 || $fetch_style === \PDO::FETCH_DEFAULT) {
             $fetch_style = $this->fetchMode;
         }
 
@@ -415,7 +415,7 @@ trait FakePdoStatementTrait
      */
     public function universalFetchAll(int $fetch_style = -123, ...$args) : array
     {
-        if ($fetch_style === -123) {
+        if ($fetch_style === -123 || $fetch_style === \PDO::FETCH_DEFAULT) {
             $fetch_style = $this->fetchMode;
             $fetch_argument = $this->fetchArgument;
             $ctor_args = $this->fetchConstructorArgs;

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -34,6 +34,28 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         $this->assertSame([], $query->fetchAll(\PDO::FETCH_ASSOC));
     }
 
+    public function testSelectFetchDefault()
+    {
+        $pdo = self::getConnectionToFullDB();
+
+        $query = $pdo->prepare("SELECT id FROM `video_game_characters` WHERE `id` > :id ORDER BY `id` ASC");
+        $query->bindValue(':id', 14);
+        $query->execute();
+
+        $this->assertSame(
+            ['id' => '15', 0 => '15'],
+            $query->fetch(\PDO::FETCH_DEFAULT)
+        );
+
+        $this->assertSame(
+            [
+                ['id' => '15', 0 => '15'],
+                ['id' => '16', 0 => '16']
+            ],
+            $query->fetchAll(\PDO::FETCH_DEFAULT)
+        );
+    }
+
     public function testSelectFetchAssoc()
     {
         $pdo = self::getConnectionToFullDB();


### PR DESCRIPTION
We've overridden the default value to our magic -123, which normally works, but if someone passes in `PDO::FETCH_DEFAULT` manually the method can't recognize it and throw an unimplemented error. This just makes sure the default is interpretted the same as -123, better matching the standard.

Added an appropriate test as well.