### PR TITLE
add mysql 8 utf8 default charset to character set map.

### DIFF
--- a/src/Processor/CreateProcessor.php
+++ b/src/Processor/CreateProcessor.php
@@ -50,6 +50,7 @@ final class CreateProcessor
         'utf32' => 'utf32_general_ci',
         'utf8' => 'utf8_general_ci',
         'utf8mb4' => 'utf8mb4_general_ci',
+        'utf8mb3' => 'utf8mb3_general_ci'
     ];
 
     public static function makeTableDefinition(


### PR DESCRIPTION
Default character set for utf8 in mysql 8 has changed to utf8mb3 for which there is not entry in the character set map. 