### PR TITLE
Make Sure PDO::FETCH_DEFAULT is Defined

### DIFF
--- a/src/FakePdoStatementTrait.php
+++ b/src/FakePdoStatementTrait.php
@@ -339,7 +339,7 @@ trait FakePdoStatementTrait
         $cursor_orientation = \PDO::FETCH_ORI_NEXT,
         $cursor_offset = 0
     ) {
-        if ($fetch_style === -123 || $fetch_style === \PDO::FETCH_DEFAULT) {
+        if ($fetch_style === -123 || (defined('PDO::FETCH_DEFAULT') && $fetch_style === \PDO::FETCH_DEFAULT)) {
             $fetch_style = $this->fetchMode;
         }
 
@@ -415,7 +415,7 @@ trait FakePdoStatementTrait
      */
     public function universalFetchAll(int $fetch_style = -123, ...$args) : array
     {
-        if ($fetch_style === -123 || $fetch_style === \PDO::FETCH_DEFAULT) {
+        if ($fetch_style === -123 || (defined('PDO::FETCH_DEFAULT') && $fetch_style === \PDO::FETCH_DEFAULT)) {
             $fetch_style = $this->fetchMode;
             $fetch_argument = $this->fetchArgument;
             $ctor_args = $this->fetchConstructorArgs;

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -54,6 +54,10 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
 
     public function testSelectFetchDefault()
     {
+        if (!defined('PDO::FETCH_DEFAULT')) {
+            $this->markTestSkipped('PHP version does not support PDO::FETCH_DEFAULT');
+        }
+
         $pdo = self::getConnectionToFullDB();
 
         $query = $pdo->prepare("SELECT id FROM `video_game_characters` WHERE `id` > :id ORDER BY `id` ASC");


### PR DESCRIPTION
PDO::FETCH_DEFAULT arrived as of PHP v8.0.7.  For those still on 7.4 referring to it directly in the code causes it to break with an undefined constant.

This checks to make sure the constant exists before comparing against it.