### PR TITLE
Fix for SELECT with OFFSET

### DIFF
--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -125,7 +125,7 @@ abstract class Processor
         }
 
         return new QueryResult(
-            \array_slice($result->rows, $offset, $rowcount, true),
+            \array_slice($result->rows, $offset, $rowcount),
             $result->columns
         );
     }

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -805,6 +805,18 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    public function testSelectWithOffset()
+    {
+        $pdo = self::getConnectionToFullDB(false);
+        $query = $pdo->prepare("SELECT `id` FROM `video_game_characters` ORDER BY `id` LIMIT 10000 OFFSET 1");
+        $query->execute();
+
+        $this->assertSame(
+            ['id' => 2],
+            $query->fetch(\PDO::FETCH_ASSOC)
+        );
+    }
+
     public function testLastInsertIdAfterSkippingAutoincrement()
     {
         $pdo = self::getConnectionToFullDB(false);


### PR DESCRIPTION
SELECT WITH OFFSET is broken:
```
<?php
declare(strict_types=1);

include __DIR__.'/../vendor/autoload.php';

$pdo = new \Vimeo\MysqlEngine\Php8\FakePdo('mysql:dbname=depo;host=localhost', 'user', 'password');
$pdo->query('CREATE TABLE `test` (`id` INT NOT NULL) ENGINE=innodb DEFAULT CHARSET=utf8');
$pdo->query('INSERT INTO `test`(`id`) VALUES (1), (2)');

$stmt = $pdo->query('SELECT * FROM `test` LIMIT 10');
var_dump($stmt->fetch());
/*
Correct:
array(2) {
  ["id"]=>
  string(1) "1"
  [0]=>
  string(1) "1"
}
 */


$stmt = $pdo->query('SELECT * FROM `test` LIMIT 10 OFFSET 1');
var_dump($stmt->fetch());
/*
Expected:
array(2) {
  ["id"]=>
  string(1) "2"
  [0]=>
  string(1) "2"
}
Actual:
bool(false)
 */
```

I added a test and a fix for it.