### PR TITLE
feat: INSERT...SELECT syntax implementation.

### DIFF
--- a/src/Parser/SelectParser.php
+++ b/src/Parser/SelectParser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Vimeo\MysqlEngine\Parser;
 
 use Vimeo\MysqlEngine\Query\Expression\ColumnExpression;
@@ -46,6 +47,11 @@ final class SelectParser
         $this->pointer = $pointer;
         $this->tokens = $tokens;
         $this->sql = $sql;
+    }
+
+    public function getPointer(): int
+    {
+        return $this->pointer;
     }
 
     public function parse() : SelectQuery

--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Vimeo\MysqlEngine\Query;
 
 use Vimeo\MysqlEngine\Query\Expression\BinaryOperatorExpression;
@@ -40,6 +41,9 @@ final class InsertQuery
      * @var array<int, BinaryOperatorExpression>|null
      */
     public $setClause = null;
+
+    /** @var SelectQuery|null $selectExpression */
+    public $selectQuery = null;
 
     public function __construct(string $table, string $sql, bool $ignoreDupes)
     {

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -918,13 +918,15 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
 
         $query = $pdo->prepare(
             "INSERT INTO `video_game_characters`
-                (`id`, `name`, `type`, `profession`, `console`, `is_alive`, `powerups`, `skills`, `created_on`)
+                (`name`, `type`, `profession`, `console`, `is_alive`, `powerups`, `skills`, `created_on`)
                 SELECT
-                    19+`id`, 'wario','villain','plumber','nes','1','3','{\"magic\":0, \"speed\":0, \"strength\":0, \"weapons\":0}', NOW(), 
+                    'wario','villain','plumber','nes','1','3','{\"magic\":0, \"speed\":0, \"strength\":0, \"weapons\":0}', NOW(), 
                 FROM `video_game_characters`"
         );
 
         $query->execute();
+
+        self::assertEquals($pdo->lastInsertId(), 32);
 
         $query = $pdo->prepare(
             'SELECT `id`, `name`
@@ -937,7 +939,7 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(
             [
-                ['id' => 35, 'name' => 'wario'],
+                ['id' => 32, 'name' => 'wario'],
             ],
             $query->fetchAll(PDO::FETCH_ASSOC)
         );

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Vimeo\MysqlEngine\Tests;
 
+use PDO;
 use PDOException;
 
 class EndToEndTest extends \PHPUnit\Framework\TestCase
@@ -908,6 +909,37 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
                 ['bio_en' => '', 'bio_fr' => null],
             ],
             $query->fetchAll(\PDO::FETCH_ASSOC)
+        );
+    }
+
+    public function testInsertWithSelect(): void
+    {
+        $pdo = self::getConnectionToFullDB(false);
+
+        $query = $pdo->prepare(
+            "INSERT INTO `video_game_characters`
+                (`id`, `name`, `type`, `profession`, `console`, `is_alive`, `powerups`, `skills`, `created_on`)
+                SELECT
+                    19+`id`, 'wario','villain','plumber','nes','1','3','{\"magic\":0, \"speed\":0, \"strength\":0, \"weapons\":0}', NOW(), 
+                FROM `video_game_characters`"
+        );
+
+        $query->execute();
+
+        $query = $pdo->prepare(
+            'SELECT `id`, `name`
+            FROM `video_game_characters`
+            ORDER BY `id` DESC
+            LIMIT 1'
+        );
+
+        $query->execute();
+
+        $this->assertSame(
+            [
+                ['id' => 35, 'name' => 'wario'],
+            ],
+            $query->fetchAll(PDO::FETCH_ASSOC)
         );
     }
 


### PR DESCRIPTION
This PR implements support for INSERT ... SELECT syntax in php-mysql-engine.

Previously, the engine supported INSERT ... VALUES and INSERT ... SET, but INSERT ... SELECT was not implemented.
This implementation modifies the INSERT parser and processor to call the necessary components for handling SELECT, enabling the execution of INSERT ... SELECT statements.