### PR TITLE
feat: Improve GROUP_CONCAT Behavior – Consider GROUP BY and Support DISTINCT, ORDER BY, and SEPARATOR Options

### DIFF
--- a/src/Parser/ExpressionParser.php
+++ b/src/Parser/ExpressionParser.php
@@ -137,9 +137,13 @@ final class ExpressionParser
         $needs_comma = false;
         $args = [];
 
+        if (isset($tokens[0]) && $tokens[0]->value == "DISTINCT") {
+            $distinct = true;
+            $pos++;
+        }
+
         while ($pos < $token_count) {
             $arg = $tokens[$pos];
-
 
             if ($arg->value === ',') {
                 if ($needs_comma) {
@@ -151,6 +155,13 @@ final class ExpressionParser
                 }
             }
 
+
+            if ($arg->value === 'ORDER') {
+                $p = new OrderByParser($pos, $tokens);
+                [$pos, $order_by] = $p->parse();
+                continue;
+            }
+
             $p = new ExpressionParser($tokens, $pos - 1);
             list($pos, $expr) = $p->buildWithPointer();
             $args[] = $expr;
@@ -158,7 +169,7 @@ final class ExpressionParser
             $needs_comma = true;
         }
 
-        return [$distinct, $args];
+        return [$distinct, $args, $order_by ?? null];
     }
 
     /**

--- a/src/Processor/Expression/BinaryOperatorEvaluator.php
+++ b/src/Processor/Expression/BinaryOperatorEvaluator.php
@@ -66,7 +66,9 @@ final class BinaryOperatorEvaluator
                         $left,
                         $right,
                     ],
-                    false
+                    false,
+                    null,
+                    null
                 ),
                 $row,
                 $result

--- a/src/Processor/Expression/FunctionEvaluator.php
+++ b/src/Processor/Expression/FunctionEvaluator.php
@@ -1,6 +1,7 @@
 <?php
 namespace Vimeo\MysqlEngine\Processor\Expression;
 
+use Closure;
 use Vimeo\MysqlEngine\FakePdoInterface;
 use Vimeo\MysqlEngine\Processor\ProcessorException;
 use Vimeo\MysqlEngine\Processor\QueryResult;
@@ -938,26 +939,62 @@ final class FunctionEvaluator
      * @param array<string, mixed> $row
      */
     private static function sqlGroupConcat(
-        FakePdoInterface $conn,
-        Scope $scope,
+        FakePdoInterface   $conn,
+        Scope              $scope,
         FunctionExpression $expr,
-        QueryResult $result
-    ): string {
+        QueryResult        $result
+    ): string
+    {
         $args = $expr->args;
 
         $items = [];
         foreach ($result->rows as $row) {
             $tmp_str = "";
+            /** @var Closure(array{direction: "ASC"|"DESC", expression: Expression}): ?scalar $func */
+            /** @psalm-suppress MissingClosureReturnType */
+            $func = function (array $order) use ($result, $row, $scope, $conn) {
+                /** @var array{expression: Expression} $order */
+                return Evaluator::evaluate($conn, $scope, $order["expression"], $row, $result);
+            };
+            $orders = array_map(
+                $func,
+                $expr->order ?? []
+            );
             foreach ($args as $arg) {
-                $val = (string) Evaluator::evaluate($conn, $scope, $arg, $row, $result);
+                $val = (string)Evaluator::evaluate($conn, $scope, $arg, $row, $result);
                 $tmp_str .= $val;
             }
             if ($tmp_str !== "" && (!$expr->distinct || !isset($items[$tmp_str]))) {
-                $items[$tmp_str] = $tmp_str;
+                $items[$tmp_str] = ["val" => $tmp_str, "orders" => $orders];
             }
         }
 
-        return implode(",", array_values($items));
+        usort($items, function ($a, $b) use ($expr): int {
+            /**
+             * @var array{val: string, orders: array<int, scalar>} $a
+             * @var array{val: string, orders: array<int, scalar>} $b
+             */
+            for ($i = 0; $i < count($expr->order ?? []); $i++) {
+                $direction = $expr->order[$i]["direction"] ?? 'ASC';
+                $a_val = $a["orders"][$i];
+                $b_val = $b["orders"][$i];
+
+                if ($a_val < $b_val) {
+                    return ($direction === 'ASC') ? -1 : 1;
+                } elseif ($a_val > $b_val) {
+                    return ($direction === 'ASC') ? 1 : -1;
+                }
+            }
+            return 0;
+        });
+
+        if (isset($expr->separator)) {
+            $separator = (string)(Evaluator::evaluate($conn, $scope, $expr->separator, [], $result));
+        } else {
+            $separator = ",";
+        }
+
+        return implode($separator, array_column($items, 'val'));
     }
 
     /**

--- a/src/Query/Expression/FunctionExpression.php
+++ b/src/Query/Expression/FunctionExpression.php
@@ -1,9 +1,8 @@
 <?php
+
 namespace Vimeo\MysqlEngine\Query\Expression;
 
 use Vimeo\MysqlEngine\Parser\Token;
-use Vimeo\MysqlEngine\TokenType;
-use Vimeo\MysqlEngine\Processor\ProcessorException;
 
 final class FunctionExpression extends Expression
 {
@@ -31,12 +30,23 @@ final class FunctionExpression extends Expression
      * @var bool
      */
     public $distinct;
+    /** @var ?array<int, array{expression: Expression, direction: 'ASC'|'DESC'}> $order */
+    public $order;
+    /** @var ?Expression $separator */
+    public $separator;
 
     /**
      * @param Token $token
-     * @param array<int, Expression>                                $args
+     * @param array<int, Expression> $args
+     * @param ?array<int, array{expression: Expression, direction: 'ASC'|'DESC'}> $order
      */
-    public function __construct(Token $token, array $args, bool $distinct)
+    public function __construct(
+        Token  $token,
+        array  $args,
+        bool   $distinct,
+        ?array  $order,
+        ?Expression $separator
+    )
     {
         $this->token = $token;
         $this->args = $args;
@@ -45,8 +55,10 @@ final class FunctionExpression extends Expression
         $this->precedence = 0;
         $this->functionName = $token->value;
         $this->name = $token->value;
-        $this->operator = (string) $this->type;
+        $this->operator = $this->type;
         $this->start = $token->start;
+        $this->separator = $separator;
+        $this->order = $order;
     }
 
     /**
@@ -57,7 +69,7 @@ final class FunctionExpression extends Expression
         return $this->functionName;
     }
 
-    public function hasAggregate() : bool
+    public function hasAggregate(): bool
     {
         if ($this->functionName === 'COUNT'
             || $this->functionName === 'SUM'

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Vimeo\MysqlEngine\Tests;
 
 use PDOException;
@@ -906,6 +907,33 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(
             [
                 ['bio_en' => '', 'bio_fr' => null],
+            ],
+            $query->fetchAll(\PDO::FETCH_ASSOC)
+        );
+    }
+
+    public function testGroupConcat()
+    {
+        $pdo = self::getConnectionToFullDB(false);
+
+        $query = $pdo->prepare(
+            'SELECT `type`, GROUP_CONCAT(DISTINCT `profession`) as `profession_list`
+            FROM `video_game_characters`
+            GROUP BY `type`'
+        );
+
+        $query->execute();
+
+        $this->assertSame(
+            [
+                [
+                    "type" => "hero",
+                    "profession_list" => "plumber,hedgehog,earthworm,monkey,pokemon,princess,boxer,yellow circle,dinosaur,not sure,sure"
+                ],
+                [
+                    "type" => "villain",
+                    "profession_list" => "evil dinosaur,evil doctor,throwing shit from clouds,evil chain dude"
+                ],
             ],
             $query->fetchAll(\PDO::FETCH_ASSOC)
         );

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -917,7 +917,7 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         $pdo = self::getConnectionToFullDB(false);
 
         $query = $pdo->prepare(
-            'SELECT `type`, GROUP_CONCAT(DISTINCT `profession`) as `profession_list`
+            'SELECT `type`, GROUP_CONCAT(DISTINCT `profession` ORDER BY `name` SEPARATOR \' \') as `profession_list`
             FROM `video_game_characters`
             GROUP BY `type`'
         );
@@ -928,11 +928,11 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
             [
                 [
                     "type" => "hero",
-                    "profession_list" => "plumber,hedgehog,earthworm,monkey,pokemon,princess,boxer,yellow circle,dinosaur,not sure,sure"
+                    "profession_list" => "monkey sure earthworm not sure boxer plumber yellow circle pokemon princess hedgehog dinosaur"
                 ],
                 [
                     "type" => "villain",
-                    "profession_list" => "evil dinosaur,evil doctor,throwing shit from clouds,evil chain dude"
+                    "profession_list" => "evil dinosaur evil chain dude evil doctor throwing shit from clouds"
                 ],
             ],
             $query->fetchAll(\PDO::FETCH_ASSOC)


### PR DESCRIPTION
This pull request improves the behaviour of the GROUP_CONCAT function in php-mysql-engine to provide MySQL-compliant aggregation. The main changes include:

- Adjusting the implementation so that if a GROUP BY clause is present, all rows are processed instead of always returning only the first row.
- Implement the DISTINCT option to remove duplicate values.
- Support the ORDER BY option to sort results based on the expression evaluated (in both ASC and DESC directions).
- A SEPARATOR option has been added to allow customisation of the output delimiter (default is a comma).