### PR TITLE
fix the negation evaluations in fake sql

### DIFF
--- a/src/Processor/Expression/BinaryOperatorEvaluator.php
+++ b/src/Processor/Expression/BinaryOperatorEvaluator.php
@@ -152,7 +152,7 @@ final class BinaryOperatorEvaluator
                             return !$expr->negatedInt;
                         }
 
-                        return $l_value == $r_value ? 1 : 0 ^ $expr->negatedInt;
+                        return ($l_value == $r_value ? 1 : 0 ) ^ $expr->negatedInt;
 
                     case '<>':
                     case '!=':
@@ -165,35 +165,35 @@ final class BinaryOperatorEvaluator
                             return $expr->negatedInt;
                         }
 
-                        return $l_value != $r_value ? 1 : 0 ^ $expr->negatedInt;
+                        return ($l_value != $r_value ? 1 : 0) ^ $expr->negatedInt;
 
                     case '>':
                         if ($as_string) {
-                            return (string) $l_value > (string) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                            return ((string) $l_value > (string) $r_value ? 1 : 0) ^ $expr->negatedInt;
                         }
 
-                        return (float) $l_value > (float) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                        return ((float) $l_value > (float) $r_value ? 1 : 0 ) ^ $expr->negatedInt;
                         // no break
                     case '>=':
                         if ($as_string) {
-                            return (string) $l_value >= (string) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                            return ((string) $l_value >= (string) $r_value ? 1 : 0) ^ $expr->negatedInt;
                         }
 
-                        return (float) $l_value >= (float) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                        return ((float) $l_value >= (float) $r_value ? 1 : 0) ^ $expr->negatedInt;
 
                     case '<':
                         if ($as_string) {
-                            return (string) $l_value < (string) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                            return ((string) $l_value < (string) $r_value ? 1 : 0) ^ $expr->negatedInt;
                         }
 
-                        return (float) $l_value < (float) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                        return ((float) $l_value < (float) $r_value ? 1 : 0) ^ $expr->negatedInt;
 
                     case '<=':
                         if ($as_string) {
-                            return (string) $l_value <= (string) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                            return ((string) $l_value <= (string) $r_value ? 1 : 0) ^ $expr->negatedInt;
                         }
 
-                        return (float) $l_value <= (float) $r_value ? 1 : 0 ^ $expr->negatedInt;
+                        return ((float) $l_value <= (float) $r_value ? 1 : 0) ^ $expr->negatedInt;
                 }
 
                 // PHPCS thinks there's a fallthrough here, but there provably is not

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -1214,6 +1214,46 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
             $query->fetch(\PDO::FETCH_ASSOC)
         );
     }
+        
+    public function testNegateOperationWithAnd()
+    {
+        // greater than
+        $pdo = self::getConnectionToFullDB(false);
+        $query = $pdo->prepare("SELECT COUNT(*) as 'count' FROM `video_game_characters` WHERE `console` = :console AND NOT (`powerups` > :powerups)");
+        $query->bindValue(':console', 'nes');
+        $query->bindValue(':powerups', 3);
+        $query->execute();
+
+        $this->assertSame([['count' => 8]], $query->fetchAll(\PDO::FETCH_ASSOC));
+
+        // equals
+        $query = $pdo->prepare("SELECT COUNT(*) as 'count' FROM `video_game_characters` WHERE `console` = :console AND NOT (`powerups` = :powerups)");
+        $query->bindValue(':console', 'nes');
+        $query->bindValue(':powerups', 0);
+        $query->execute();
+
+        $this->assertSame([['count' => 2]], $query->fetchAll(\PDO::FETCH_ASSOC));
+    }
+
+    public function testNegateOperationWithOr()
+    {
+        // greater than
+        $pdo = self::getConnectionToFullDB(false);
+        $query = $pdo->prepare("SELECT COUNT(*) as 'count' FROM `video_game_characters` WHERE `console` = :console OR NOT (`powerups` > :powerups)");
+        $query->bindValue(':console', 'nes');
+        $query->bindValue(':powerups', 3);
+        $query->execute();
+
+        $this->assertSame([['count' => 16]], $query->fetchAll(\PDO::FETCH_ASSOC));
+
+        // equals
+        $query = $pdo->prepare("SELECT COUNT(*) as 'count' FROM `video_game_characters` WHERE `console` = :console OR NOT (`powerups` = :powerups)");
+        $query->bindValue(':console', 'nes');
+        $query->bindValue(':powerups', 0);
+        $query->execute();
+
+        $this->assertSame([['count' => 9]], $query->fetchAll(\PDO::FETCH_ASSOC));
+    }
 
     private static function getPdo(string $connection_string, bool $strict_mode = false) : \PDO
     {


### PR DESCRIPTION
**What's changed**
Negate both results from the binary operation evaluation to ensure negation is correctly applied.

**How negation works** 

Negated Property - indicates an expression needs to be negated, | NegatedInt - used in bitwise XOR operation
-- | --
True | 1
False | 0


<p class="p2">If a 1 needs to be negated, 1 ^ 1<span class="Apple-converted-space">  </span>= 0</p>
<p class="p2">If a 0 needs to be negated, 0 ^ 1 = 1</p>
<p class="p1"><br></p>
<p class="p2">If 1 doesn’t need to be negated, 1 ^ 0  = 1</p>
<p class="p2">If 0 doesn’t need to be negated, 0 ^ 0  =  0</p>

**NOTE:**
There is some parsing issue where when a single NOT statement is applied directly after WHERE clause, the `negated` property is not set correctly. Took a look but couldn't fix it in a short time so gonna leave it for now. We don't write NOT for a single statement anyways since we use `!=` or `NOT IN` directly. 


**Example**

Prior to the change, the following query will return the count 9, because `NOT (powerups > :powerups)` is always true, and the result doesn't filter out the character `luigi`, who has `nes` console and `5` powerups.

```
        // greater than
        $pdo = self::getConnectionToFullDB(false);
        $query = $pdo->prepare("SELECT COUNT(*) as 'count' FROM `video_game_characters` WHERE `console` = :console AND NOT (`powerups` > :powerups)");
        $query->bindValue(':console', 'nes');
        $query->bindValue(':powerups', 3);
        $query->execute();

        $query->fetchAll(\PDO::FETCH_ASSOC));
```

After the change, the count result is 8.

**Tests**
Added unit tests
