### PR TITLE
fixes duplicate key error when limit operation is applied with UPDATE statement

### DIFF
--- a/src/Processor/Processor.php
+++ b/src/Processor/Processor.php
@@ -125,7 +125,7 @@ abstract class Processor
         }
 
         return new QueryResult(
-            \array_slice($result->rows, $offset, $rowcount),
+            \array_slice($result->rows, $offset, $rowcount, true),
             $result->columns
         );
     }

--- a/tests/EndToEndTest.php
+++ b/tests/EndToEndTest.php
@@ -826,18 +826,6 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testSelectWithOffset()
-    {
-        $pdo = self::getConnectionToFullDB(false);
-        $query = $pdo->prepare("SELECT `id` FROM `video_game_characters` ORDER BY `id` LIMIT 10000 OFFSET 1");
-        $query->execute();
-
-        $this->assertSame(
-            ['id' => 2],
-            $query->fetch(\PDO::FETCH_ASSOC)
-        );
-    }
-
     public function testLastInsertIdAfterSkippingAutoincrement()
     {
         $pdo = self::getConnectionToFullDB(false);
@@ -1213,6 +1201,25 @@ class EndToEndTest extends \PHPUnit\Framework\TestCase
             ['nullable_field' => null, 'nullable_field_default_0' => null],
             $query->fetch(\PDO::FETCH_ASSOC)
         );
+    }
+
+    public function testUpdate()
+    {
+        $pdo = self::getConnectionToFullDB(false);
+
+        // before update
+        $query = $pdo->prepare("SELECT `type` FROM `video_game_characters` WHERE `id` = 3");
+        $query->execute();
+        $this->assertSame([['type' => 'hero']], $query->fetchAll(\PDO::FETCH_ASSOC));
+
+        // prepare update
+        $query = $pdo->prepare("UPDATE `video_game_characters` SET `type` = 'villain' WHERE `id` = 3 LIMIT 1");
+        $query->execute();
+
+        // after update
+        $query = $pdo->prepare("SELECT `type` FROM `video_game_characters` WHERE `id` = 3");
+        $query->execute();
+        $this->assertSame([['type' => 'villain']], $query->fetchAll(\PDO::FETCH_ASSOC));
     }
         
     public function testNegateOperationWithAnd()


### PR DESCRIPTION
revert changes introduced in - https://github.com/vimeo/php-mysql-engine/commit/9bbc63a03f2dc81798b763408fd538c462b6a68f.

It breaks our existing `UPDATE` statement with `LIMIT` Clause. 

Before the fix, row ids are reindexed after the `LIMIT` operation, which causes duplicate key error because the original row is not excluded from the unique key comparison

<img width="904" height="133" alt="Screenshot 2025-08-14 at 4 39 36 PM" src="https://github.com/user-attachments/assets/fd8105a7-ea5c-4c7b-a53b-0d073460980b" />

After the fix, `UPDATE` statement with `LIMIT 1` clause is executed correctly

**Tests** 
Added unit tests

