### PR TITLE
ensures double negative is evaluated correctly

### DIFF
--- a/src/Query/Expression/BinaryOperatorExpression.php
+++ b/src/Query/Expression/BinaryOperatorExpression.php
@@ -69,8 +69,8 @@ final class BinaryOperatorExpression extends Expression
      */
     public function negate()
     {
-        $this->negated = true;
-        $this->negatedInt = 1;
+        $this->negated = !$this->negated;
+        $this->negatedInt = $this->negated ? 1 : 0;
     }
 
     /**


### PR DESCRIPTION
**what's changed**
Update the `negate` function in BinaryOperatorExpression to negate the existing value. This allows expressions with double negative, such as `NOT (:gameboy IS NOT NULL)`, to negate correctly.

**Example**
Prior to the change, the following query will return count 16 because  `NOT ("gameboy" IS NOT NULL)` is evaluated to `TRUE` and making the whole WHERE clause always `TRUE`. The expression, `NOT ("gameboy" IS NOT NULL)` should be `FALSE` because if `"gameboy" IS NOT NULL` is true, then `NOT(TRUE)` is `FALSE`
```
$query = $pdo->prepare("SELECT COUNT(*) as 'count' FROM `video_game_characters` WHERE (:console IS NOT NULL AND `console` = :console) OR NOT (:console IS NOT NULL)");
        $query->bindValue(':console', 'gameboy');
        $query->execute();
```

After the change, the query returns 1 correctly. 

**Tests**
Add tests with queries involving `IS NULL` AND `IS NOT NULL`