### PR TITLE
feat: Add support for `@@session.time_zone` system variable

### DIFF
--- a/src/Processor/Expression/VariableEvaluator.php
+++ b/src/Processor/Expression/VariableEvaluator.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace Vimeo\MysqlEngine\Processor\Expression;
 
+use Vimeo\MysqlEngine\Processor\ProcessorException;
 use Vimeo\MysqlEngine\Query\Expression\VariableExpression;
 use Vimeo\MysqlEngine\Processor\Scope;
 
@@ -8,13 +10,34 @@ final class VariableEvaluator
 {
     /**
      * @return mixed
+     * @throws ProcessorException
      */
     public static function evaluate(Scope $scope, VariableExpression $expr)
     {
+        if (strpos($expr->variableName, '@') === 0) {
+            return self::getSystemVariable(substr($expr->variableName, 1));
+        }
+
         if (\array_key_exists($expr->variableName, $scope->variables)) {
             return $scope->variables[$expr->variableName];
         }
 
         return null;
+    }
+
+    /**
+     * @param string $variableName
+     *
+     * @return string
+     * @throws ProcessorException
+     */
+    private static function getSystemVariable(string $variableName): string
+    {
+        switch ($variableName) {
+            case 'session.time_zone':
+                return date_default_timezone_get();
+            default:
+                throw new ProcessorException("System variable $variableName is not supported yet!");
+        }
     }
 }

--- a/tests/VariableEvaluatorTest.php
+++ b/tests/VariableEvaluatorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vimeo\MysqlEngine\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class VariableEvaluatorTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        \Vimeo\MysqlEngine\Server::reset();
+    }
+
+    public function testSessionTimeZone(): void
+    {
+        $query = $this->getPdo()
+            ->prepare('SELECT @@session.time_zone');
+        $query->execute();
+        $result = $query->fetch(\PDO::FETCH_COLUMN);
+
+        $this->assertSame(date_default_timezone_get(), $result);
+    }
+
+    public function testNotImplementedGlobalVariable(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage("The SQL code SELECT @@collation_server; could not be evaluated");
+
+        $query = $this->getPdo()
+            ->prepare('SELECT @@collation_server;');
+        $query->execute();
+        $result = $query->fetch(\PDO::FETCH_COLUMN);
+
+        $this->assertSame(date_default_timezone_get(), $result);
+    }
+
+    public function testVariable(): void
+    {
+        $sql = "
+            SELECT (@var := @var + 2) AS `counter`
+            FROM (SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3) AS `virtual_rows`
+            CROSS JOIN (SELECT @var := 0) AS `vars`;
+        ";
+
+        $query = $this->getPdo()
+            ->prepare($sql);
+        $query->execute();
+        $result = $query->fetchAll(\PDO::FETCH_ASSOC);
+        $counters = array_map('intval', array_column($result, 'counter'));
+        $this->assertSame([2,4,6], $counters);
+    }
+
+    private function getPdo(bool $strict_mode = false): \PDO
+    {
+        $connection_string = 'mysql:foo;dbname=test;';
+        $options = $strict_mode ? [\PDO::MYSQL_ATTR_INIT_COMMAND => 'SET sql_mode="STRICT_ALL_TABLES"'] : [];
+
+        if (\PHP_MAJOR_VERSION === 8) {
+            return new \Vimeo\MysqlEngine\Php8\FakePdo($connection_string, '', '', $options);
+        }
+
+        return new \Vimeo\MysqlEngine\Php7\FakePdo($connection_string, '', '', $options);
+    }
+}


### PR DESCRIPTION
This pull request introduces support for the `@@session.time_zone` system variable, enabling users to retrieve the session's current timezone.

This feature aligns the library's behavior with MySQL's and improves its compatibility for applications that rely on timezone-aware operations.