### PR TITLE
fix: Resolve evaluation issues in SUM() and CONVERT_TZ() functions

### DIFF
--- a/src/Processor/Expression/FunctionEvaluator.php
+++ b/src/Processor/Expression/FunctionEvaluator.php
@@ -353,9 +353,13 @@ final class FunctionEvaluator
     }
 
     /**
-     * @param array<string, Column> $columns
+     * @param FakePdoInterface $conn
+     * @param Scope $scope
+     * @param FunctionExpression $expr
+     * @param QueryResult $result
      *
-     * @return ?numeric
+     * @return float|int|mixed|string|null
+     * @throws ProcessorException
      */
     private static function sqlSum(
         FakePdoInterface $conn,
@@ -368,6 +372,10 @@ final class FunctionEvaluator
         $sum = 0;
 
         if (!$result->rows) {
+            if ($expr instanceof FunctionExpression) {
+                return self::evaluate($conn, $scope, $expr, [], $result);
+            }
+
             return null;
         }
 
@@ -1573,6 +1581,10 @@ final class FunctionEvaluator
 
         if (count($args) !== 3) {
             throw new \InvalidArgumentException("CONVERT_TZ() requires exactly 3 arguments");
+        }
+
+        if ($args[0] instanceof ColumnExpression && empty($row)) {
+            return null;
         }
 
         /** @var string|null $dtValue */


### PR DESCRIPTION
This PR addresses two evaluation issues in SQL functions:

1.  **SUM() Evaluation:** The change ensures that the `SUM()` function can correctly evaluate expressions (e.g., `SUM(a + b)`).

2.  **CONVERT_TZ() Null Handling:** A check has been added to the `CONVERT_TZ()` function to handle cases where a column expression is empty (`null`). This prevents a fatal error and ensures the function behaves gracefully when processing incomplete or missing data.